### PR TITLE
DEV: Explicitly define primary_email_verified? method for Google One Tap authenticator

### DIFF
--- a/lib/google_one_tap_authenticator.rb
+++ b/lib/google_one_tap_authenticator.rb
@@ -23,4 +23,8 @@ class GoogleOneTapAuthenticator < Auth::ManagedAuthenticator
   def register_middleware(omniauth)
     omniauth.provider(OmniAuth::Strategies::GoogleOneTap)
   end
+
+  def primary_email_verified?(auth_token)
+    true
+  end
 end


### PR DESCRIPTION
Related core PR: https://github.com/discourse/discourse/pull/19127.

Internal topic: t/82084.