### PR TITLE
FIX: Redirect back to topic/category/tag routes

### DIFF
--- a/lib/google_one_tap.rb
+++ b/lib/google_one_tap.rb
@@ -24,6 +24,10 @@ module OmniAuth
         # Ref: https://developers.google.com/identity/gsi/web/guides/verify-google-id-token
         validate_csrf!
         self.access_token = build_access_token # It builds and validate it!.
+        # The `origin` query param is set server-side when rendering the
+        # g_id_onload div so that users are redirected back to the page they
+        # were on when authentication started.
+        env["omniauth.origin"] = request.params["origin"] if request.params["origin"].present?
         super
       rescue GoogleOneTapCSFRError => e
         fail!(:invalid_csrf_token, e)

--- a/plugin.rb
+++ b/plugin.rb
@@ -25,6 +25,10 @@ after_initialize do
     end
   end
 
+  # Path prefixes that are eligible to be passed back as the post-login
+  # redirect target. Other routes fall through to the homepage.
+  prefixes = %w[/t/ /c/ /tag/ /tags/].freeze
+
   register_html_builder("server:before-body-close") do |ctx|
     #This return the div Google JS (loaded above will use)
     #This could also be done in pure JS
@@ -40,12 +44,11 @@ after_initialize do
       # back to it after authentication. We can't rely on cookies here because
       # Google POSTs to the callback from a cross-site context (SameSite=Lax
       # cookies aren't sent on cross-site POST navigations).
-      #
-      # Only topic, category, and tag pages are eligible for redirect — other
-      # routes fall through to the homepage.
       login_uri = +"#{Discourse.base_url}/auth/google_one_tap/callback"
       origin = ctx.request.fullpath
-      eligible_prefixes = %w[/t/ /c/ /tag/ /tags/].map { "#{Discourse.base_path}#{_1}" }
+
+      eligible_prefixes = prefixes.map { "#{Discourse.base_path}#{_1}" }
+
       if origin.present? && eligible_prefixes.any? { origin.start_with?(_1) }
         login_uri << "?origin=#{CGI.escape(origin)}"
       end

--- a/plugin.rb
+++ b/plugin.rb
@@ -35,13 +35,29 @@ after_initialize do
     #> Failure to do so may result in project suspension, account suspension, or both.
     # Ref https://developers.google.com/identity/gsi/web/guides/change-position
     result = ""
-    result = <<~HTML if !ctx.current_user && ctx.request.cookies["authentication_data"].blank?
+    if !ctx.current_user && ctx.request.cookies["authentication_data"].blank?
+      # Pass the current page path to the callback so the user can be redirected
+      # back to it after authentication. We can't rely on cookies here because
+      # Google POSTs to the callback from a cross-site context (SameSite=Lax
+      # cookies aren't sent on cross-site POST navigations).
+      #
+      # Only topic, category, and tag pages are eligible for redirect — other
+      # routes fall through to the homepage.
+      login_uri = +"#{Discourse.base_url}/auth/google_one_tap/callback"
+      origin = ctx.request.fullpath
+      eligible_prefixes = %w[/t/ /c/ /tag/ /tags/].map { "#{Discourse.base_path}#{_1}" }
+      if origin.present? && eligible_prefixes.any? { origin.start_with?(_1) }
+        login_uri << "?origin=#{CGI.escape(origin)}"
+      end
+
+      result = <<~HTML
         <div id="g_id_onload"
           data-client_id="#{SiteSetting.google_oauth2_client_id}"
-          data-login_uri="#{Discourse.base_url}/auth/google_one_tap/callback"
+          data-login_uri="#{login_uri}"
           data-itp_support="true">
         </div>
       HTML
+    end
     result
   end
 end

--- a/spec/requests/google_one_tap_spec.rb
+++ b/spec/requests/google_one_tap_spec.rb
@@ -199,4 +199,45 @@ describe "Google One Tap" do
     expect(response.location).to eq("http://test.localhost/")
     expect(cookies[:_t]).to be_present
   end
+
+  it "redirects to the origin param when provided and valid" do
+    post "/auth/google_one_tap/callback?origin=%2Ft%2Fsome-topic%2F123",
+         params: {
+           g_csrf_token: "abcdefg",
+           credential: build_jwt_token(email: user.email),
+         },
+         headers: {
+           "HTTP_COOKIE" => "g_csrf_token=abcdefg",
+         }
+    expect(response.status).to eq(302)
+    expect(response.location).to eq("http://test.localhost/t/some-topic/123")
+    expect(cookies[:_t]).to be_present
+  end
+
+  it "sets destination_url in authentication_data to the origin param for signups" do
+    post "/auth/google_one_tap/callback?origin=%2Ft%2Fsome-topic%2F123",
+         params: {
+           g_csrf_token: "abcdefg",
+           credential: build_jwt_token,
+         },
+         headers: {
+           "HTTP_COOKIE" => "g_csrf_token=abcdefg",
+         }
+    expect(response.status).to eq(302)
+    expect(response.location).to eq("http://test.localhost/t/some-topic/123")
+    expect(JSON.parse(cookies[:authentication_data])["destination_url"]).to eq("/t/some-topic/123")
+  end
+
+  it "ignores the origin param when it points to an auth path" do
+    post "/auth/google_one_tap/callback?origin=%2Fauth%2Fgoogle_one_tap",
+         params: {
+           g_csrf_token: "abcdefg",
+           credential: build_jwt_token(email: user.email),
+         },
+         headers: {
+           "HTTP_COOKIE" => "g_csrf_token=abcdefg",
+         }
+    expect(response.status).to eq(302)
+    expect(response.location).to eq("http://test.localhost/")
+  end
 end


### PR DESCRIPTION
Where relevant, we should return the user to the path they came from.